### PR TITLE
Revert "Loose coupling"

### DIFF
--- a/jnc/src/com/tailf/jnc/Capabilities.java
+++ b/jnc/src/com/tailf/jnc/Capabilities.java
@@ -1,7 +1,6 @@
 package com.tailf.jnc;
 
 import java.util.ArrayList;
-import java.util.List;
 
 public class Capabilities {
 
@@ -309,8 +308,8 @@ public class Capabilities {
         return urlSchemes;
     }
 
-    private final List<Capa> capas;
-    private final List<Capa> data_capas;
+    private final ArrayList<Capa> capas;
+    private final ArrayList<Capa> data_capas;
 
     static private class Capa {
         String uri;

--- a/jnc/src/com/tailf/jnc/Device.java
+++ b/jnc/src/com/tailf/jnc/Device.java
@@ -3,7 +3,6 @@ package com.tailf.jnc;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class provides features for managing a device with NETCONF.
@@ -88,20 +87,20 @@ public class Device implements Serializable {
     /**
      * The NETCONF sessions (channels) for this device.
      */
-    protected transient List<SessionConnData> connSessions;
-    protected transient List<SessionTree> trees;
+    protected transient ArrayList<SessionConnData> connSessions;
+    protected transient ArrayList<SessionTree> trees;
 
     /**
      * A list of configuration changes. The backlog is saved when a
      * configuration change is made and the device is down, so that it can be
      * re-sent later when the device comes up again.
      */
-    protected List<Element> backlog;
+    protected ArrayList<Element> backlog;
 
     /**
      * A list of users.
      */
-    protected List<DeviceUser> users;
+    protected ArrayList<DeviceUser> users;
 
     /**
      * ip address as string
@@ -170,7 +169,7 @@ public class Device implements Serializable {
     /**
      * Return the list of users.
      */
-    public List<DeviceUser> getUsers() {
+    public ArrayList<DeviceUser> getUsers() {
         return users;
     }
 

--- a/jnc/src/com/tailf/jnc/Element.java
+++ b/jnc/src/com/tailf/jnc/Element.java
@@ -5,7 +5,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A configuration element sub-tree. Makes it possible to create and/or
@@ -59,9 +62,9 @@ public class Element implements Serializable {
     public Object value;
 
     /**
-     * Attributes on the node. List of Attribute.
+     * Attributes on the node. ArrayList of Attribute.
      */
-    List<Attribute> attrs;
+    ArrayList<Attribute> attrs;
 
     /**
      * Prefix map are really xmlns attributes. For example:

--- a/jnc/src/com/tailf/jnc/NetconfSession.java
+++ b/jnc/src/com/tailf/jnc/NetconfSession.java
@@ -2,7 +2,6 @@ package com.tailf.jnc;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A NETCONF session class. It makes it possible to connect to a NETCONF agent
@@ -1545,7 +1544,7 @@ public class NetconfSession {
         proprietaryClientCaps.add(capability);
     }
 
-    private List<String> proprietaryClientCaps;
+    private ArrayList<String> proprietaryClientCaps;
 
     /**
      * Used by ConfDSession to set the withDefaults Attribute. Will be included

--- a/jnc/src/com/tailf/jnc/Path.java
+++ b/jnc/src/com/tailf/jnc/Path.java
@@ -1,7 +1,6 @@
 package com.tailf.jnc;
 
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A path expression. This is a small subset of the W3C recommendations of
@@ -97,7 +96,7 @@ public class Path {
     /**
      * The list of location steps (LocationStep).
      */
-    List<LocationStep> locationSteps;
+    ArrayList<LocationStep> locationSteps;
 
     /**
      * The original path string.
@@ -124,7 +123,7 @@ public class Path {
         int axis;
         String name;
         String prefix;
-        List<Expr> predicates; // list of Expr (Predicates)
+        ArrayList<Expr> predicates; // list of Expr (Predicates)
 
         LocationStep(int axis) {
             this.axis = axis;
@@ -766,7 +765,7 @@ public class Path {
      * Returns a list of LocationSteps for a path expression.
      * 
      */
-    List<LocationStep> parse(TokenList tokens) throws JNCException {
+    ArrayList<LocationStep> parse(TokenList tokens) throws JNCException {
         final ArrayList<LocationStep> steps = new ArrayList<LocationStep>();
         try {
             Token tok1, tok2, tok3, tok4, tok5;

--- a/jnc/src/com/tailf/jnc/SSHSession.java
+++ b/jnc/src/com/tailf/jnc/SSHSession.java
@@ -8,7 +8,6 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.List;
 
 import ch.ethz.ssh2.ChannelCondition;
 import ch.ethz.ssh2.Session;
@@ -38,7 +37,7 @@ public class SSHSession implements Transport {
 
     private BufferedReader in = null;
     private PrintWriter out = null;
-    private final List<IOSubscriber> ioSubscribers;
+    private final ArrayList<IOSubscriber> ioSubscribers;
     protected long readTimeout = 0; // millisecs
 
     private static final String endmarker = "]]>]]>";

--- a/jnc/src/com/tailf/jnc/SchemaParser.java
+++ b/jnc/src/com/tailf/jnc/SchemaParser.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -61,13 +59,13 @@ public class SchemaParser {
     }
 
     private class SchemaHandler extends DefaultHandler {
-        protected Map<Tagpath, SchemaNode> h;
+        protected HashMap<Tagpath, SchemaNode> h;
         protected SchemaNode node;
         protected RevisionInfo ri;
-        protected List<RevisionInfo> riArrayList;
+        protected ArrayList<RevisionInfo> riArrayList;
         protected String value = null;
 
-        SchemaHandler(Map<Tagpath, SchemaNode> h2) {
+        SchemaHandler(HashMap<Tagpath, SchemaNode> h2) {
             super();
             h = h2;
         }
@@ -164,7 +162,7 @@ public class SchemaParser {
      * @param h The hashtable to populate.
      * @throws JNCException If there is an IO or SAX parse problem.
      */
-    public void readFile(String filename, Map<Tagpath, SchemaNode> h)
+    public void readFile(String filename, HashMap<Tagpath, SchemaNode> h)
             throws JNCException {
         readFile(new InputSource(filename), h);
     }
@@ -177,7 +175,7 @@ public class SchemaParser {
      * @param h The hashtable to populate.
      * @throws JNCException If there is an IO or SAX parse problem.
      */
-    public void readFile(URL schemaUrl, Map<Tagpath, SchemaNode> h)
+    public void readFile(URL schemaUrl, HashMap<Tagpath, SchemaNode> h)
             throws JNCException {
         try {
             readFile(new InputSource(schemaUrl.openStream()), h);
@@ -189,7 +187,7 @@ public class SchemaParser {
     }
 
     private void readFile(InputSource inputSource,
-            Map<Tagpath, SchemaNode> h) throws JNCException {
+            HashMap<Tagpath, SchemaNode> h) throws JNCException {
         try {
             final SchemaHandler handler = new SchemaHandler(h);
             parser.setContentHandler(handler);
@@ -211,7 +209,7 @@ public class SchemaParser {
      * @param clazz
      * @throws JNCException if the file is not found or cannot be parsed.
      */
-    public void findAndReadFile(final String filename, final Map<Tagpath, SchemaNode> h, final Class clazz)
+    public void findAndReadFile(final String filename, final HashMap<Tagpath, SchemaNode> h, final Class clazz)
             throws JNCException {
         final URL url = clazz.getResource(filename);
         if (url == null){

--- a/jnc/src/com/tailf/jnc/SchemaTree.java
+++ b/jnc/src/com/tailf/jnc/SchemaTree.java
@@ -1,7 +1,6 @@
 package com.tailf.jnc;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -9,7 +8,7 @@ import java.util.Set;
  */
 public class SchemaTree {
 
-    private static Map<String, HashMap<Tagpath, SchemaNode>> namespaces = new HashMap<String, HashMap<Tagpath, SchemaNode>>();
+    private static HashMap<String, HashMap<Tagpath, SchemaNode>> namespaces = new HashMap<String, HashMap<Tagpath, SchemaNode>>();
 
     /**
      * If no hashmap exists for namespace, it is created. Used by generated
@@ -18,7 +17,7 @@ public class SchemaTree {
      * @param namespace The namespace of the module as a String.
      * @return The HashMap associated with namespace.
      */
-    public static Map<Tagpath, SchemaNode> create(String namespace) {
+    public static HashMap<Tagpath, SchemaNode> create(String namespace) {
         if (namespaces.containsKey(namespace)) {
             return namespaces.get(namespace);
         }
@@ -31,7 +30,7 @@ public class SchemaTree {
      * @param namespace A YANG module namespace as a String
      * @return The HashMap associated with namespace, or null.
      */
-    public static Map<Tagpath, SchemaNode> getHashMap(String namespace) {
+    public static HashMap<Tagpath, SchemaNode> getHashMap(String namespace) {
         return namespaces.get(namespace);
     }
 
@@ -52,7 +51,7 @@ public class SchemaTree {
      *         namespace, or null if not found.
      */
     public static SchemaNode lookup(String namespace, Tagpath tp) {
-        final Map<Tagpath, SchemaNode> t = getHashMap(namespace);
+        final HashMap<Tagpath, SchemaNode> t = getHashMap(namespace);
         return t == null ? null : t.get(tp);
     }
 

--- a/jnc/src/com/tailf/jnc/YangElement.java
+++ b/jnc/src/com/tailf/jnc/YangElement.java
@@ -3,7 +3,6 @@ package com.tailf.jnc;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The YangElement is a configuration sub-tree like the
@@ -255,7 +254,7 @@ public abstract class YangElement extends Element {
      * Static list of packages.
      * 
      */
-    static List<Package> packages = new ArrayList<Package>();
+    static ArrayList<Package> packages = new ArrayList<Package>();
 
     /**
      * Locate package from Namespace.


### PR DESCRIPTION
klacke I was looking at unit test coverage this morning for the jnc folder, its quite low < 30% 

So I decided to run some some integration tests against confd. 

Before getting this far I noticed that pyang generates code that is dependent on concrete types, as a result one of the commits last night thats moves from concrete to interfaces will break the generated code.

Please merge this revert for that single commit. 

Going forward I will only send you updates that have been verified against confd, separately I will look at beefing up the unit tests.

This reverts commit bf64e98049578b1defe953a5e4f0cde8c1156409.
