### PR TITLE
Adding pom.xml for Maven Central distribution

### DIFF
--- a/jnc/build.xml
+++ b/jnc/build.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0"?>
-<project name="java-junit-template-project" default="test" basedir=".">
-    <property name="main.build.dir" value="build/main"/>
-    <property name="main.src.dir" value="src"/>
-    <property name="main.lib.dir" value="lib"/>
-    <property name="test.build.dir" value="build/test"/>
-    <property name="test.src.dir" value="test"/>
-    <property name="jar.build.dir" value="build/jar"/>
+<project name="java-junit-template-project" default="test" basedir="." 
+         xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+
+    <property name="lib" value="lib"/>
+    <property name="src-main" value="src"/>
+    <property name="src-test" value="test"/>
+    <property name="build" location="build" />
+    <property name="build-main" value="build/main"/>
+    <property name="build-test" value="build/test"/>
+    <property name="build-jar" value="build/jar"/>
+    <property name="dist" location="dist" />
 
     <path id="classpath.base">
         <pathelement location="lib/ganymed-ssh2-262.jar"/>
@@ -14,40 +18,43 @@
     <path id="classpath.test">
         <pathelement location="lib/junit-4.11.jar"/>
         <pathelement location="lib/hamcrest-core-1.3.jar"/>
-        <pathelement location="${main.build.dir}"/>
+        <pathelement location="${build-main}"/>
         <path refid="classpath.base"/>
     </path>
 
     <target name="get-deps">
-        <mkdir dir="lib"/>
+        <mkdir dir="${lib}"/>
         <get src="http://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar"
-             dest="${main.lib.dir}/junit-4.11.jar"
+             dest="${lib}/junit-4.11.jar"
              usetimestamp="true"/>
         <get src="http://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-             dest="${main.lib.dir}/hamcrest-core-1.3.jar"
+             dest="${lib}/hamcrest-core-1.3.jar"
              usetimestamp="true"/>
         <get src="http://repo1.maven.org/maven2/ch/ethz/ganymed/ganymed-ssh2/262/ganymed-ssh2-262.jar"
-             dest="${main.lib.dir}/ganymed-ssh2-262.jar"
+             dest="${lib}/ganymed-ssh2-262.jar"
              usetimestamp="true"/>
     </target>
 
     <target name="clean" depends="get-deps">
         <delete>
             <fileset dir="${basedir}" includes="**/*.class"/>
+            <fileset dir="${basedir}" includes="**/*.asc"/>
         </delete>
+        <delete dir="${build}" />
+        <delete dir="${dist}" />
         <echo message="clean done"/>
     </target>
 
     <target name="compile" depends="clean">
-        <mkdir dir="${main.build.dir}"/>
-        <javac srcdir="${main.src.dir}" destdir="${main.build.dir}" includeantruntime="false">
+        <mkdir dir="${build-main}"/>
+        <javac srcdir="${src-main}" destdir="${build-main}" includeantruntime="false">
             <classpath refid="classpath.base"/>
         </javac>
     </target>
 
     <target name="compile-test" depends="compile">
-        <mkdir dir="${test.build.dir}"/>
-        <javac srcdir="${test.src.dir}" destdir="${test.build.dir}" includeantruntime="false">
+        <mkdir dir="${build-test}"/>
+        <javac srcdir="${src-test}" destdir="${build-test}" includeantruntime="false">
             <classpath refid="classpath.test"/>
         </javac>
     </target>
@@ -56,18 +63,131 @@
         <junit printsummary="on" haltonfailure="yes">
             <classpath>
                 <path refid="classpath.test"/>
-                <pathelement location="${test.build.dir}"/>
-                <pathelement location="${test.src.dir}/resources"/>
+                <pathelement location="${build-test}"/>
+                <pathelement location="${src-test}/resources"/>
             </classpath>
             <formatter type="brief" usefile="false"/>
             <batchtest>
-                <fileset dir="${test.src.dir}" includes="**/*Test*.java"/>
+                <fileset dir="${src-test}" includes="**/*Test*.java"/>
             </batchtest>
         </junit>
     </target>
 
     <target name="jar" depends="test">
-        <jar destfile="${jar.build.dir}/JNC.jar" basedir="${main.build.dir}"/>
+        <jar destfile="${build-jar}/JNC.jar" basedir="${build-main}"/>
+        <!-- Building a second copy of the jar for maven -->
+        <jar destfile="${jar}" basedir="${build-main}"/>
+    </target>
+
+    <!-- ********* BEGIN MAVEN CENTRAL DEPLOYMENT SECTION ********** -->
+
+    <!-- define Maven coordinates -->
+    <property name="groupId" value="com.tailf" />
+    <property name="artifactId" value="jnc" />
+    <property name="version" value="1.0" />
+
+    <!-- define artifacts' name, which follows the convention of Maven -->
+    <property name="jar" value="${dist}/lib/${artifactId}-${version}.jar" />
+    <property name="javadoc-jar" value="${dist}/lib/${artifactId}-${version}-javadoc.jar" />
+    <property name="sources-jar" value="${dist}/lib/${artifactId}-${version}-sources.jar" />
+
+    <!-- defined maven snapshots and staging repository id and url -->
+    <property name="ossrh-snapshots-repository-url" 
+              value="https://oss.sonatype.org/content/repositories/snapshots/" />
+    <property name="ossrh-staging-repository-url" 
+              value="https://oss.sonatype.org/service/local/staging/deploy/maven2/" />
+
+    <!-- there server id in the Maven settings.xml -->
+    <property name="ossrh-server-id" value="ossrh" />
+
+    <!-- typedef to maven ant artifact -->
+    <property name="maven-ant" value="${lib}/maven-ant-tasks-2.1.3.jar" />
+    <path id="maven-ant-tasks.classpath" path="${maven-ant}" />
+    <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
+             uri="antlib:org.apache.maven.artifact.ant"
+             classpathref="maven-ant-tasks.classpath" />
+
+    <target name="setup-stage" description="get the maven ant artifact">
+        <mkdir dir="${lib}"/>
+        <get src="http://apache.mirrors.pair.com/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar"
+             dest="${maven-ant}"
+             usetimestamp="true"/>
+    </target>
+    
+    <target name="dist" depends="jar" description="build javadoc and sources jar">
+        <mkdir dir="${dist}/lib" />
+
+        <!-- build the javadoc jar -->
+        <javadoc sourcepath="${src-main}" destdir="${dist}/javadoc" />
+        <jar jarfile="${javadoc-jar}">
+          <fileset dir="${dist}/javadoc" />
+        </jar>
+    
+        <!-- build the sources jar -->
+        <jar jarfile="${sources-jar}">
+          <fileset dir="${src-main}" />
+        </jar>
+    </target>
+
+    <target name="deploy" depends="dist" description="deploy snapshot version to Maven snapshot repository">
+        <fail message="file ${maven-ant} missing${line.separator}${line.separator}** Run 'ant setup-stage' to download it.">
+            <condition>
+                <not>
+                    <available file="${maven-ant}" />
+                </not>
+            </condition>
+        </fail>
+
+        <artifact:mvn>
+            <arg value="org.apache.maven.plugins:maven-deploy-plugin:2.6:deploy-file" />
+            <arg value="-Durl=${ossrh-snapshots-repository-url}" />
+            <arg value="-DrepositoryId=${ossrh-server-id}" />
+            <arg value="-DpomFile=pom.xml" />
+            <arg value="-Dfile=${jar}" />
+        </artifact:mvn>
+    </target>
+
+    <!-- before this, update project version (both build.xml and pom.xml) from SNAPSHOT to RELEASE -->
+    <target name="stage" depends="dist" description="deploy release version to Maven staging repository">
+        <fail message="file ${maven-ant} missing${line.separator}${line.separator}** Run 'ant setup-stage' to download it.">
+            <condition>
+                <not>
+                    <available file="${maven-ant}" />
+                </not>
+            </condition>
+        </fail>
+
+        <!-- sign and deploy the main artifact -->
+        <artifact:mvn>
+            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+            <arg value="-Durl=${ossrh-staging-repository-url}" />
+            <arg value="-DrepositoryId=${ossrh-server-id}" />
+            <arg value="-DpomFile=pom.xml" />
+            <arg value="-Dfile=${jar}" />
+            <arg value="-Pgpg" />
+        </artifact:mvn>
+
+        <!-- sign and deploy the sources artifact -->
+        <artifact:mvn>
+            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+            <arg value="-Durl=${ossrh-staging-repository-url}" />
+            <arg value="-DrepositoryId=${ossrh-server-id}" />
+            <arg value="-DpomFile=pom.xml" />
+            <arg value="-Dfile=${sources-jar}" />
+            <arg value="-Dclassifier=sources" />
+            <arg value="-Pgpg" />
+        </artifact:mvn>
+
+        <!-- sign and deploy the javadoc artifact -->
+        <artifact:mvn>
+            <arg value="org.apache.maven.plugins:maven-gpg-plugin:1.3:sign-and-deploy-file" />
+            <arg value="-Durl=${ossrh-staging-repository-url}" />
+            <arg value="-DrepositoryId=${ossrh-server-id}" />
+            <arg value="-DpomFile=pom.xml" />
+            <arg value="-Dfile=${javadoc-jar}" />
+            <arg value="-Dclassifier=javadoc" />
+            <arg value="-Pgpg" />
+        </artifact:mvn>
     </target>
 
 </project>

--- a/jnc/pom.xml
+++ b/jnc/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.tailf</groupId>
+  <artifactId>jnc</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>JNC</name>
+  <description>JNC (Java NETCONF Client) is the name of a Java library for communicating with NETCONF agents.</description>
+  <url>https://github.com/tail-f-systems/JNC</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <organization>Tail-f Systems</organization>
+      <organizationUrl>http://www.tail-f.com/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:tail-f-systems/JNC.git</connection>
+    <developerConnection>scm:git:git@github.com:tail-f-systems/JNC.git</developerConnection>
+    <url>git@github.com:tail-f-systems/JNC.git</url>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>ch.ethz.ganymed</groupId>
+      <artifactId>ganymed-ssh2</artifactId>
+      <version>262</version>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
Also, adding several targets to build.xml to facilitate uploading the maven artifact to Maven Central.

Based on recommendations from Sonatype: http://central.sonatype.org/pages/apache-ant.html

To deploy the artifacts, you need to do the following:
1. Create an account: http://central.sonatype.org/pages/ossrh-guide.html
2. Create the ~/.m2/settings file: http://central.sonatype.org/pages/apache-ant.html (near the bottom)
3. Run "ant setup-stage" to download the maven ant plugin
4. Run "ant stage" to stage the artifacts with sonatype
5. Close and release the repository, wait 15 minutes and it will be in Maven Central.

