### PR TITLE
Use Long.parseLong for session id since it is specced to be unsigned.

### DIFF
--- a/jnc/src/com/tailf/jnc/IOSubscriber.java
+++ b/jnc/src/com/tailf/jnc/IOSubscriber.java
@@ -113,7 +113,7 @@ public abstract class IOSubscriber {
         }
     }
 
-    void outputPrint(int iVal) {
+    void outputPrint(long iVal) {
         final StringBuffer tmp = new StringBuffer(16);
         tmp.append(iVal);
         for (int i = 0; i < tmp.length(); i++) {

--- a/jnc/src/com/tailf/jnc/NetconfSession.java
+++ b/jnc/src/com/tailf/jnc/NetconfSession.java
@@ -161,7 +161,7 @@ public class NetconfSession {
      * Session identifier. Received from the initial <code>hello</code>
      * message.
      */
-    public int sessionId;
+    public long sessionId;
 
     /**
      * The capability elements for the session. Retrieved from
@@ -323,7 +323,7 @@ public class NetconfSession {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "hello contains no session identifier");
         }
-        sessionId = Integer.parseInt((String) sess.value);
+        sessionId = Long.parseLong((String) sess.value);
         trace("sessionId = " + sessionId);
     }
 
@@ -1169,7 +1169,7 @@ public class NetconfSession {
      * 
      * @param sessionId The id of the session to terminate
      */
-    public void killSession(int sessionId) throws JNCException, IOException {
+    public void killSession(long sessionId) throws JNCException, IOException {
         trace("killSession: " + sessionId);
         if (sessionId == this.sessionId) {
             throw new JNCException(JNCException.SESSION_ERROR,
@@ -2338,7 +2338,7 @@ public class NetconfSession {
      * &lt;/rpc&gt;
      * </pre>
      */
-    int encode_killSession(Transport out, int sessionId) {
+    int encode_killSession(Transport out, long sessionId) {
         final int mid = encode_rpc_begin(out);
         out.println("<" + nc + "kill-session>");
         out.print("<" + nc + "session-id>");

--- a/jnc/src/com/tailf/jnc/SSHSession.java
+++ b/jnc/src/com/tailf/jnc/SSHSession.java
@@ -229,7 +229,7 @@ public class SSHSession implements Transport {
      * @param iVal Text to send to the stream.
      */
     @Override
-    public void print(int iVal) {
+    public void print(long iVal) {
         for (final IOSubscriber sub : ioSubscribers) {
             sub.outputPrint(iVal);
         }

--- a/jnc/src/com/tailf/jnc/Transport.java
+++ b/jnc/src/com/tailf/jnc/Transport.java
@@ -28,7 +28,7 @@ public interface Transport {
     /**
      * Prints an integer to the transport output stream.
      */
-    public void print(int i);
+    public void print(long i);
 
     /**
      * Prints a string to the transport output stream.


### PR DESCRIPTION
This fixes the NumberFormatException due to number overflow when parsing the session id.