### PR TITLE
container and its parent can have the same name now

### DIFF
--- a/tests/10-test-nested/Makefile
+++ b/tests/10-test-nested/Makefile
@@ -1,0 +1,37 @@
+usage:
+	@echo "make all          Build all"
+	@echo "make clean        Remove all built and intermediary files"
+	@echo "make start        Start ConfD daemon"
+	@echo "make stop         Stop any ConfD daemon"
+
+ifndef CONFD_DIR
+$(error "Enviroment variable CONFD_DIR has not been set.")
+endif
+
+# Include standard ConfD build definitions and rules
+include $(CONFD_DIR)/src/confd/build/include.mk
+
+# In case CONFD_DIR is not set (correctly), this rule will trigger
+$(CONFD_DIR)/src/confd/build/include.mk:
+	@echo 'Where is ConfD installed? Set $$CONFD_DIR to point it out!'
+	@echo ''
+	@exit 1
+
+# Example specific definitions and rules
+CONFD_HOST ?= localhost
+CONFD_FLAGS = --addloadpath $(CONFD_DIR)/etc/confd
+START_FLAGS ?=
+
+all: nesting.fxs ssh-keydir $(CDB_DIR)
+	@echo "Build complete"
+
+$(CDB_DIR)/aaa_init.xml: ../confd/aaa_init.xml $(CDB_DIR)
+	@cp $< $@
+
+clean:	iclean
+
+start:  stop
+	$(CONFD) -c ../confd/confd.conf $(CONFD_FLAGS)
+
+stop:
+	$(CONFD) --stop || true

--- a/tests/10-test-nested/build.gradle
+++ b/tests/10-test-nested/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'application'
+}
+
+assert (System.env.CONFD_DIR): "CONFD_DIR is not set!"
+
+jncPyang {
+    outputDir = new File("${buildDir}/generated/src")
+    yangPath = "$System.env.CONFD_DIR/src/confd/yang"
+    inputFiles = [new File("$projectDir/nesting.yang")]
+}
+
+compileJava.dependsOn([jncPyang])
+sourceSets.main.java.srcDirs = ["src", "${buildDir}/generated/src"]
+
+application {
+    mainClass = 'app.Client'
+    applicationDefaultJvmArgs = ['-enableassertions']
+}

--- a/tests/10-test-nested/nested.yang
+++ b/tests/10-test-nested/nested.yang
@@ -1,0 +1,15 @@
+module union {
+  namespace "http://acme.com/ns/nested/1.0";
+  prefix nested;
+  list nested {
+    key k;
+    leaf k {
+      type string;
+    }
+    container nested {
+      leaf l {
+        type string;
+      }
+    }
+  }
+}

--- a/tests/10-test-nested/nesting.yang
+++ b/tests/10-test-nested/nesting.yang
@@ -1,0 +1,15 @@
+module nesting {
+  namespace "http://acme.com/ns/nesting/1.0";
+  prefix nesting;
+  list nested {
+    key k;
+    leaf k {
+      type string;
+    }
+    container nested {
+      leaf l {
+        type string;
+      }
+    }
+  }
+}

--- a/tests/10-test-nested/src/app/Client.java
+++ b/tests/10-test-nested/src/app/Client.java
@@ -1,0 +1,80 @@
+package app;
+
+import java.io.IOException;
+
+import nesting.Nesting;
+import nesting.Nested;
+
+import com.tailf.jnc.Device;
+import com.tailf.jnc.DeviceUser;
+import com.tailf.jnc.JNCException;
+import com.tailf.jnc.NetconfSession;
+import com.tailf.jnc.NodeSet;
+
+public class Client {
+
+    private Device dev;
+
+    public Client() {
+        this.init();
+    }
+
+    private void init() {
+        String emsUserName = "bobby";
+        String host = "localhost";
+        DeviceUser duser = new DeviceUser(emsUserName, "admin", "admin");
+        dev = new Device("mydev", duser, host, 2022);
+
+        try {
+            dev.connect(emsUserName, 2000, false);
+            dev.newSession("cfg");
+        } catch (IOException e) {
+            System.err.println(e);
+            System.exit(1);
+        } catch (JNCException e) {
+            System.err.println("Can't authenticate " + e);
+            System.exit(1);
+        }
+    }
+
+    public void editConfig(final NodeSet config) throws IOException, JNCException {
+        editConfig(dev, config);
+    }
+
+    private void editConfig(final Device dev, final NodeSet config) throws IOException,
+            JNCException {
+        dev.getSession("cfg").editConfig(config);
+    }
+
+    public NodeSet getConfig(final String xpath) throws IOException, JNCException {
+        NetconfSession session = dev.getSession("cfg");
+        return session.getConfig(NetconfSession.RUNNING, xpath);
+    }
+
+    public static void main(final String[] args) throws IOException, JNCException {
+        Client client = new Client();
+        Nesting.enable();
+        client.init();
+        NodeSet configs = client.getConfig("/nested");
+        assert configs.size() == 0;
+
+        Nested inst1 = new Nested("k1"),
+            inst2 = new Nested("k2");
+        inst1.addNested().setLValue("l1");
+        inst2.addNested().setLValue("l2");
+        configs.add(inst1);
+        configs.add(inst2);
+        client.editConfig(configs);
+
+        NodeSet configs2 = client.getConfig("/nested");
+        assert configs2.size() == 2;
+        assert configs2.get(0) instanceof Nested;
+        assert configs2.get(1) instanceof Nested;
+        assert "l1".equals(((Nested)configs2.get(0)).nested.getLValue());
+        assert "l1".equals(((Nested)configs2.get(1)).nested.getLValue());
+        configs2.get(0).markDelete();
+        configs2.get(1).markDelete();
+        client.editConfig(configs);
+        client.dev.close();
+    }
+}

--- a/tests/settings.gradle
+++ b/tests/settings.gradle
@@ -1,3 +1,4 @@
+include '10-test-nested'
 include '11-test-notification'
 include '12-test-augment'
 include '1-test-union'

--- a/tests/test_full_jnc.py
+++ b/tests/test_full_jnc.py
@@ -34,6 +34,7 @@ class JncTestBase:
                         '5-test-bits',
                         '6-test-binary',
                         '7-test-uint64',
+                        '10-test-nested',
                         '11-test-notification',
                         '12-test-augment'])
 def jnc_test(request):
@@ -63,7 +64,7 @@ def run_notifier(jnc_test):
 def test_run_jnc(jnc_test):
     if jnc_test.basedir == '11-test-notification':
         run_notifier(jnc_test)
-    jnc_test.jnc_runner.expect('BUILD SUCCESSFUL in')
+    jnc_test.jnc_runner.expect('BUILD SUCCESSFUL')
     jnc_test.jnc_runner.expect(pexpect.EOF)
     jnc_test.jnc_runner.close()
     assert 0 == jnc_test.jnc_runner.exitstatus


### PR DESCRIPTION
Some ClassGenerator attributes contained lists instead of JavaValue instances; with that fixed, the generated Java code was still invalid due to the name clash.
Note that the changes are in the pyang plugin, so before its new version is published on PyPI, the source code pyang plugin needs to be used.