### PR TITLE
trace format strings fix

### DIFF
--- a/src/main/java/com/tailf/jnc/Element.java
+++ b/src/main/java/com/tailf/jnc/Element.java
@@ -175,7 +175,7 @@ public class Element implements Cloneable, Serializable {
      */
     public static Element create(PrefixMap prefixMap, String pathStr)
             throws JNCException {
-        trace("create: \"{}\"", pathStr);
+        trace("create: \"%s\"", pathStr);
         final PathCreate path = new PathCreate(pathStr);
         final Element t = path.eval(prefixMap);
         t.setPrefix(prefixMap);
@@ -358,7 +358,7 @@ public class Element implements Cloneable, Serializable {
      */
     public Element createPath(int mode, PrefixMap addPrefixes, String pathStr)
             throws JNCException {
-        trace("createPath: \"{}\"", pathStr);
+        trace("createPath: \"%s\"", pathStr);
         final PathCreate path = new PathCreate(pathStr);
         if (addPrefixes != null) {
             setPrefix(addPrefixes);
@@ -726,7 +726,7 @@ public class Element implements Cloneable, Serializable {
      * @return The configuration attribute.
      */
     public Attribute setAttr(String name, String value) {
-        trace("setAttr: {}=\"{}\"", name, value);
+        trace("setAttr: %s=\"%s\"", name, value);
         if ("xmlns".equals(name)) {
             // it's an xmlns attribute - treat this as a prefix map
             final Prefix p = new Prefix("", value);
@@ -766,7 +766,7 @@ public class Element implements Cloneable, Serializable {
      * @return The configuration attribute.
      */
     public Attribute setAttr(String ns, String name, String value) {
-        trace("setAttr: ({}) {}=\"{}\"", ns, name, value);
+        trace("setAttr: (%s) %s=\"%s\"", ns, name, value);
         if (name.startsWith("xmlns") && ns.startsWith(Prefix.XMLNS_NAMESPACE)) {
             return setAttr(name, value);
         }
@@ -801,7 +801,7 @@ public class Element implements Cloneable, Serializable {
             for (int i = 0; i < attrs.size(); i++) {
                 final Attribute attr = attrs.get(i);
                 if (attr.name.equals(name)) {
-                    trace("removeAttr: {}", name);
+                    trace("removeAttr: %s", name);
                     attrs.remove(i);
                     return;
                 }
@@ -821,7 +821,7 @@ public class Element implements Cloneable, Serializable {
             for (int i = 0; i < attrs.size(); i++) {
                 final Attribute attr = attrs.get(i);
                 if (attr.name.equals(name) && attr.ns.equals(namespace)) {
-                    trace("removeAttr: ({}) {}", namespace, name);
+                    trace("removeAttr: (%s) %s", namespace, name);
                     attrs.remove(i);
                 }
             }
@@ -925,7 +925,7 @@ public class Element implements Cloneable, Serializable {
      * @param value Value to be set
      */
     public void setValue(Object value) {
-        trace("setValue: {}=\"{}\"", name, value);
+        trace("setValue: %s=\"%s\"", name, value);
         this.value = value;
     }
 

--- a/src/main/java/com/tailf/jnc/NetconfSession.java
+++ b/src/main/java/com/tailf/jnc/NetconfSession.java
@@ -324,7 +324,7 @@ public class NetconfSession {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "hello contains no capabilities");
         }
-        trace("capabilities: \n{}", capatree.toXMLString());
+        trace("capabilities: \n%s", capatree.toXMLString());
 
         capabilities = new Capabilities(capatree);
         if (!capabilities.baseCapability && !capabilities.baseCapability_v1_1) {
@@ -343,7 +343,7 @@ public class NetconfSession {
                     "hello contains no session identifier");
         }
         sessionId = Long.parseLong((String) sess.value);
-        trace("sessionId = {}", sessionId);
+        trace("sessionId = %s", sessionId);
     }
 
     /**
@@ -453,7 +453,7 @@ public class NetconfSession {
      * Gets the device configuration data.
      */
     public NodeSet getConfig(int datastore) throws JNCException, IOException {
-        trace("getConfig: {}", datastoreToString(datastore));
+        trace("getConfig: %s", datastoreToString(datastore));
         RPCRequest rpcRequest = prepareGetConfigMessage(encodeDatastore(datastore));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -503,7 +503,7 @@ public class NetconfSession {
      */
     public NodeSet getConfig(int datastore, Element subtreeFilter)
             throws JNCException, IOException {
-        trace("getConfig: {}\n{}", datastoreToString(datastore),
+        trace("getConfig: %s\n%s", datastoreToString(datastore),
               subtreeFilter.toXMLString());
         RPCRequest rpcRequest = prepareGetConfigMessage(encodeDatastore(datastore), subtreeFilter);
         out.print(rpcRequest.getMessage().toString());
@@ -520,7 +520,7 @@ public class NetconfSession {
      */
     public NodeSet getConfig(int datastore, String xpath)
             throws JNCException, IOException {
-        trace("getConfig: {} \"{}\"", datastoreToString(datastore), xpath);
+        trace("getConfig: %s \"%s\"", datastoreToString(datastore), xpath);
         if (!capabilities.xpathCapability) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "the :xpath capability is not supported by server");
@@ -563,7 +563,7 @@ public class NetconfSession {
      * @param xpath An xpath epxression.
      */
     public NodeSet get(String xpath) throws JNCException, IOException {
-        trace("get: \"{}\"", xpath);
+        trace("get: \"%s\"", xpath);
         if (!capabilities.hasXPath()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "the :xpath capability is not supported by server");
@@ -608,7 +608,7 @@ public class NetconfSession {
      */
     public void editConfig(int datastore, Element configTree)
             throws JNCException, IOException {
-        trace("editConfig: target={}\n{}", datastoreToString(datastore), configTree.toXMLString());
+        trace("editConfig: target=%s\n%s", datastoreToString(datastore), configTree.toXMLString());
         RPCRequest rpcRequest = prepareEditConfigMessage(encodeDatastore(datastore),
                 new NodeSet(configTree));
         out.print(rpcRequest.getMessage().toString());
@@ -637,7 +637,7 @@ public class NetconfSession {
      */
     public void editConfig(int datastore, String url) throws JNCException,
             IOException {
-        trace("editConfig: target={} source={}", datastoreToString(datastore), url);
+        trace("editConfig: target=%s source=%s", datastoreToString(datastore), url);
         RPCRequest rpcRequest = prepareEditConfigMessage(encodeDatastore(datastore), url);
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -874,7 +874,7 @@ public class NetconfSession {
      */
     public void copyConfig(int source, int target) throws JNCException,
             IOException {
-        trace("copyConfig: {} {}", datastoreToString(source), datastoreToString(target));
+        trace("copyConfig: %s %s", datastoreToString(source), datastoreToString(target));
         RPCRequest rpcRequest = prepareCopyConfigMessage(encodeDatastore(source), encodeDatastore(target));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -890,7 +890,7 @@ public class NetconfSession {
      */
     public void copyConfig(int source, String targetUrl) throws JNCException,
             IOException {
-        trace("copyConfig: source={} target={}", datastoreToString(source), targetUrl);
+        trace("copyConfig: source=%s target=%s", datastoreToString(source), targetUrl);
         RPCRequest rpcRequest = prepareCopyConfigMessage(encodeDatastore(source), encodeUrl(targetUrl));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -907,7 +907,7 @@ public class NetconfSession {
      */
     public void copyConfig(String sourceUrl, String targetUrl)
             throws JNCException, IOException {
-        trace("copyConfig: source={} target={}", sourceUrl, targetUrl);
+        trace("copyConfig: source=%s target=%s", sourceUrl, targetUrl);
         RPCRequest rpcRequest = prepareCopyConfigMessage(encodeUrl(sourceUrl), encodeUrl(targetUrl));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -923,7 +923,7 @@ public class NetconfSession {
      */
     public void copyConfig(String sourceUrl, int target) throws JNCException,
             IOException {
-        trace("copyConfig: source={} target={}", sourceUrl, datastoreToString(target));
+        trace("copyConfig: source=%s target=%s", sourceUrl, datastoreToString(target));
         RPCRequest rpcRequest = prepareCopyConfigMessage(encodeUrl(sourceUrl), encodeDatastore(target));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -937,7 +937,7 @@ public class NetconfSession {
      * @param datastore Datastore to be deleted
      */
     public void deleteConfig(int datastore) throws JNCException, IOException {
-        trace("deleteConfig: {}", datastoreToString(datastore));
+        trace("deleteConfig: %s", datastoreToString(datastore));
         RPCRequest rpcRequest = prepareDeleteConfigMessage(encodeDatastore(datastore));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -951,7 +951,7 @@ public class NetconfSession {
      */
     public void deleteConfig(String targetUrl) throws JNCException,
             IOException {
-        trace("deleteConfig: {}", targetUrl);
+        trace("deleteConfig: %s", targetUrl);
         RPCRequest rpcRequest = prepareDeleteConfigMessage(encodeUrl(targetUrl));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -971,7 +971,7 @@ public class NetconfSession {
      * @param datastore The datastore to lock
      */
     public void lock(int datastore) throws JNCException, IOException {
-        trace("lock: {}", datastoreToString(datastore));
+        trace("lock: %s", datastoreToString(datastore));
         RPCRequest rpcRequest = prepareLockMessage(encodeDatastore(datastore));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -985,7 +985,7 @@ public class NetconfSession {
      * @param datastore The target datastore to unlock
      */
     public void unlock(int datastore) throws JNCException, IOException {
-        trace("unlock: {}", datastoreToString(datastore));
+        trace("unlock: %s", datastoreToString(datastore));
         RPCRequest rpcRequest = prepareUnlockMessage(encodeDatastore(datastore));
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -1067,7 +1067,7 @@ public class NetconfSession {
      *            {@link #lockPartial(int,String[])}
      */
     public void unlockPartial(int lockId) throws JNCException, IOException {
-        trace("partialUnlock: {}", lockId);
+        trace("partialUnlock: %s", lockId);
         if (!capabilities.hasPartialLock()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "capability :partial-lock is not supported by server");
@@ -1152,7 +1152,7 @@ public class NetconfSession {
      *            reverting config
      */
     public void confirmedCommit(int timeout) throws JNCException, IOException {
-        trace("confirmedCommit: {}", timeout);
+        trace("confirmedCommit: %s", timeout);
         if (!capabilities.hasCandidate()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "the :candidate capability is not supported by server");
@@ -1214,7 +1214,7 @@ public class NetconfSession {
      * @param sessionId The id of the session to terminate
      */
     public void killSession(long sessionId) throws JNCException, IOException {
-        trace("killSession: {}", sessionId);
+        trace("killSession: %s", sessionId);
         if (sessionId == this.sessionId) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "illegal to use kill-session on own session id");
@@ -1232,7 +1232,7 @@ public class NetconfSession {
      * @param configTree configuration tree to validate
      */
     public void validate(Element configTree) throws JNCException, IOException {
-        trace("validate: {}", configTree.toXMLString());
+        trace("validate: %s", configTree.toXMLString());
         if (!capabilities.hasValidate()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "capability :validate is not supported by server");
@@ -1250,7 +1250,7 @@ public class NetconfSession {
      * @param datastore The datastore to validate
      */
     public void validate(int datastore) throws IOException, JNCException {
-        trace("validate: {}", datastoreToString(datastore));
+        trace("validate: %s", datastoreToString(datastore));
         if (!capabilities.hasValidate()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "capability :validate is not supported by server");
@@ -1269,7 +1269,7 @@ public class NetconfSession {
      * @param url The source url to validate
      */
     public void validate(String url) throws IOException, JNCException {
-        trace("validate: {}", url);
+        trace("validate: %s", url);
         if (!capabilities.hasValidate()) {
             throw new JNCException(JNCException.SESSION_ERROR,
                     "capability :validate is not supported by server");
@@ -1350,7 +1350,7 @@ public class NetconfSession {
     public void createSubscription(String streamName, NodeSet eventFilter,
             String startTime, String stopTime) throws IOException,
             JNCException {
-        trace("createSubscription: stream={} filter={} form={} to={}",
+        trace("createSubscription: stream=%s filter=%s form=%s to=%s",
             streamName, eventFilter.toXMLString(), startTime, stopTime);
         if (!capabilities.hasNotification()) {
             throw new JNCException(JNCException.SESSION_ERROR,
@@ -1378,7 +1378,7 @@ public class NetconfSession {
     public void createSubscription(String streamName, String eventFilter,
             String startTime, String stopTime) throws IOException,
             JNCException {
-        trace("createSubscription: stream={} filter={} from={} to={}",
+        trace("createSubscription: stream=%s filter=%s from=%s to=%s",
              streamName, eventFilter, startTime, stopTime);
         if (!capabilities.hasNotification()) {
             throw new JNCException(JNCException.SESSION_ERROR,
@@ -1422,7 +1422,7 @@ public class NetconfSession {
 
     public Element receiveNotification() throws IOException, JNCException {
         final String notification = in.readOne();
-        trace("notification= {}", notification);
+        trace("notification= %s", notification);
         if (notification.length() == 0) {
             throw new JNCException(JNCException.PARSER_ERROR, "empty input");
         }
@@ -1443,7 +1443,7 @@ public class NetconfSession {
      * @param data element tree with action-data
      */
     public Element action(Element data) throws JNCException, IOException {
-        trace("action: {}", data.toXMLString());
+        trace("action: %s", data.toXMLString());
         RPCRequest rpcRequest = prepareActionMessage(data);
         out.print(rpcRequest.getMessage().toString());
         out.flush();
@@ -1474,7 +1474,7 @@ public class NetconfSession {
      */
     protected Element recvRpcReplyOk(String mid) throws JNCException, IOException {
         final String reply = in.readOne();
-        trace("reply= {}", reply);
+        trace("reply= %s", reply);
         if (reply.length() == 0) {
             throw new JNCException(JNCException.PARSER_ERROR, "empty input");
         }
@@ -1525,7 +1525,7 @@ public class NetconfSession {
     NodeSet recvRpcReply(String path, XMLParser parser, String mid)
             throws JNCException, IOException {
         final String reply = in.readOne();
-        trace("reply= {}", reply);
+        trace("reply= %s", reply);
 
         final Element t = parser.parse(reply);
         final Element rep = t.getFirst("self::rpc-reply");

--- a/src/main/java/com/tailf/jnc/Path.java
+++ b/src/main/java/com/tailf/jnc/Path.java
@@ -49,7 +49,7 @@ public class Path {
      * @return A nodeSet of elements
      */
     public NodeSet eval(Element contextNode) throws JNCException {
-        trace("eval(): {}", this);
+        trace("eval(): %s", this);
         NodeSet nodeSet = new NodeSet();
         nodeSet.add(contextNode);
         for (final LocationStep step : locationSteps) {
@@ -70,7 +70,7 @@ public class Path {
                     "cannot eval location step: " + step + " in path");
         }
         final LocationStep locStep = locationSteps.get(step);
-        trace("evalStep(): step={}, {}", step, locStep);
+        trace("evalStep(): step=%s, %s", step, locStep);
         nodeSet = locStep.step(nodeSet);
         return nodeSet;
     }
@@ -227,7 +227,7 @@ public class Path {
          */
         Element createElem(PrefixMap prefixMap, Element parent)
                 throws JNCException {
-            trace("createElem() from {}", this);
+            trace("createElem() from %s", this);
             switch (axis) {
             case AXIS_ROOT:
                 return null;
@@ -611,7 +611,7 @@ public class Path {
          * is being created.
          */
         Object evalCreate(Element node) throws JNCException {
-            trace("evalCreate(): Expr= {}", this);
+            trace("evalCreate(): Expr= %s", this);
             // results
             Object lval = lvalue;
             Object rval = rvalue;
@@ -766,7 +766,7 @@ public class Path {
 
             int sz = tokens.size();
             while (sz > 0) {
-                trace("parse(): {}", tokens);
+                trace("parse(): %s", tokens);
                 /* peek at tokens */
                 tok1 = tokens.getToken(0);
                 if (sz >= 2) {
@@ -852,7 +852,7 @@ public class Path {
             final int errorCode = JNCException.PATH_ERROR;
             throw (JNCException) new JNCException(errorCode, "parse error").initCause(e);
         }
-        trace("parse() -> {}", steps);
+        trace("parse() -> %s", steps);
         return steps;
     }
 
@@ -875,7 +875,7 @@ public class Path {
      */
     void parsePredicates(TokenList tokens, LocationStep step)
             throws JNCException {
-        trace("parsePredicates(): {}", tokens);
+        trace("parsePredicates(): %s", tokens);
         final int sz = tokens.size();
         if (sz >= 1) {
             Token tok1 = tokens.getToken(0);
@@ -940,7 +940,7 @@ public class Path {
                 tok3 = null;
             }
 
-            trace("parsePredicate(): from={} to={} [{},{},{}, ...]",
+            trace("parsePredicate(): from=%s to=%s [%s,%s,%s, ...]",
                     from, to, tok1, tok2, tok3);
 
             /* ATOM = */
@@ -987,7 +987,7 @@ public class Path {
                 tok3 = null;
             }
 
-            trace("parsePredicate_rvalue(): from={} to={} [{}, {}, {}, ...]",
+            trace("parsePredicate_rvalue(): from=%s to=%s [%s, %s, %s, ...]",
                 from, to, tok1, tok2, tok3);
 
             if (tok1.type == ATOM && tok2 == null) {
@@ -1339,7 +1339,7 @@ public class Path {
                 i++;
             }
         }
-        trace("tokenize() -> {}", tokens);
+        trace("tokenize() -> %s", tokens);
         return tokens;
     }
 
@@ -1361,7 +1361,7 @@ public class Path {
 
     private static void trace(String format, Object ... args) {
         if (Element.debugLevel >= Element.DEBUG_LEVEL_PATH) {
-            System.err.println(String.format("*Path: {}", format, args));
+            System.err.println(String.format("*Path: " + format, args));
         }
     }
 

--- a/src/main/java/com/tailf/jnc/PathCreate.java
+++ b/src/main/java/com/tailf/jnc/PathCreate.java
@@ -36,7 +36,7 @@ public class PathCreate extends Path {
      * @return A new element tree
      */
     public Element eval(PrefixMap prefixMap) throws JNCException {
-        trace("eval(): {}", this);
+        trace("eval(): %s", this);
         Element top = null;
         Element parent = null;
 
@@ -64,7 +64,7 @@ public class PathCreate extends Path {
                     "cannot eval location step: " + step + " in create path");
         }
         final LocationStep locStep = locationSteps.get(step);
-        trace("evalStep(): step={}, {}", step, locStep);
+        trace("evalStep(): step=%s, %s", step, locStep);
         return locStep.createElem(prefixMap, parent);
     }
 

--- a/src/main/java/com/tailf/jnc/PrefixMap.java
+++ b/src/main/java/com/tailf/jnc/PrefixMap.java
@@ -64,7 +64,7 @@ public class PrefixMap extends ArrayList<Prefix> {
      * @param prefixes Prefix mappings
      */
     public void set(PrefixMap prefixes) {
-        trace("set: {}", prefixes);
+        trace("set: %s", prefixes);
         for (Prefix p : prefixes) {
             set(p);
         }

--- a/src/main/java/com/tailf/jnc/XMLParser.java
+++ b/src/main/java/com/tailf/jnc/XMLParser.java
@@ -67,15 +67,15 @@ public class XMLParser {
                         attrValue);
                 // System.out.println("ATTRIBUTE: "+attributes.getQName(i)+
                 // "  URI="+attributes.getURI(i));
-                trace("add attr: {}", attr);
+                trace("add attr: %s", attr);
                 child.addAttr(attr);
             }
             if (current == null) {
-                trace("add to top: {}", child);
+                trace("add to top: %s", child);
                 top = child;
             } else {
                 current.addChild(child);
-                trace("add child: {}", child);
+                trace("add child: %s", child);
             }
             current = child; // step down
         }
@@ -101,12 +101,12 @@ public class XMLParser {
 
         @Override
         public void startPrefixMapping(String prefix, String uri) {
-            trace("startPrefixMapping: uri=\"{}\" prefix={}", uri, prefix);
+            trace("startPrefixMapping: uri=\"%s\" prefix=%s", uri, prefix);
             if (prefixes == null) {
                 prefixes = new PrefixMap();
             }
             prefixes.add(new Prefix(prefix, uri));
-            trace("added prefixmapping: {}", prefix);
+            trace("added prefixmapping: %s", prefix);
         }
     }
 


### PR DESCRIPTION
Format strings use `"{}"` to interpolate arguments, but that does not exist in `String.format` which uses C-like interpolation.