### PR TITLE
removing double inits from tests

### DIFF
--- a/tests/1-test-union/src/app/Client.java
+++ b/tests/1-test-union/src/app/Client.java
@@ -89,7 +89,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Union.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/10-test-nested/src/app/Client.java
+++ b/tests/10-test-nested/src/app/Client.java
@@ -54,7 +54,6 @@ public class Client {
     public static void main(final String[] args) throws IOException, JNCException {
         Client client = new Client();
         Nesting.enable();
-        client.init();
         NodeSet configs = client.getConfig("/nested");
         assert configs.size() == 0;
 

--- a/tests/11-test-notification/src/app/Client.java
+++ b/tests/11-test-notification/src/app/Client.java
@@ -97,7 +97,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Notif.enable();
-        client.init();
 
         NodeSet reply = client.getStreams();
         System.out.println("got streams:" + reply.toXMLString());

--- a/tests/12-test-augment/src/app/Client.java
+++ b/tests/12-test-augment/src/app/Client.java
@@ -84,7 +84,6 @@ public class Client {
      */
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
-        client.init();
         gen.ietfSystem.Sys.enable();
         NodeSet configs = client.getConfig();
 

--- a/tests/2-test-enumeration/src/app/Client.java
+++ b/tests/2-test-enumeration/src/app/Client.java
@@ -91,7 +91,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Enumeration.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/3-test-decimal64/src/app/Client.java
+++ b/tests/3-test-decimal64/src/app/Client.java
@@ -90,7 +90,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Decimal64.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/4-test-leafref/src/app/Client.java
+++ b/tests/4-test-leafref/src/app/Client.java
@@ -89,7 +89,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Leafref.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/5-test-bits/src/app/Client.java
+++ b/tests/5-test-bits/src/app/Client.java
@@ -89,7 +89,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Bits.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/6-test-binary/src/app/Client.java
+++ b/tests/6-test-binary/src/app/Client.java
@@ -89,7 +89,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Binary.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"

--- a/tests/7-test-uint64/src/app/Client.java
+++ b/tests/7-test-uint64/src/app/Client.java
@@ -91,7 +91,6 @@ public class Client {
     public static void main(String[] args) throws IOException, JNCException {
         Client client = new Client();
         Uint64.enable();
-        client.init();
         NodeSet configs = client.getConfig();
 
         // Get (first) config with name "c"


### PR DESCRIPTION
The integration tests all contained double `init()` calls, which created two sessions towards the NETCONF server and the first one was immediately forgotten.